### PR TITLE
fixed order of arguments in stri_join for sbatch

### DIFF
--- a/R/clusterFunctionsSLURM.R
+++ b/R/clusterFunctionsSLURM.R
@@ -31,7 +31,7 @@ makeClusterFunctionsSLURM = function(template = NULL, text = NULL, clusters = NU
     assertClass(jc, "JobCollection")
 
     if (!is.null(clusters))
-      text = stri_join(sprintf("#SBATCH --clusters=%s", clusters), text, sep = "\n")
+      text = stri_join(text, sprintf("#SBATCH --clusters=%s", clusters), sep = "\n")
     outfile = cfBrewTemplate(reg, text, jc)
     res = runOSCommand("sbatch", outfile, stop.on.exit.code = FALSE, debug = reg$debug)
 


### PR DESCRIPTION
Otherwise `#SBATCH --clusters=...` will be appendend befor `#!bin/bash` and everything crashes. 