### PR TITLE
Add support for `partition` in slurm template

### DIFF
--- a/inst/templates/slurm-simple.tmpl
+++ b/inst/templates/slurm-simple.tmpl
@@ -30,6 +30,7 @@ log.file = normalizePath(log.file, winslash = "/", mustWork = FALSE)
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=<%= resources$ncpus %>
 #SBATCH --mem-per-cpu=<%= resources$memory %>
+<%= if (!is.null(resources$partition)) sprintf(paste0("#SBATCH --partition='", resources$partition, "'")) %>
 <%= if (array.jobs) sprintf("#SBATCH --array=1-%i", nrow(jobs)) else "" %>
 
 ## Initialize work environment like


### PR DESCRIPTION
This PR is an idea to enable a user to easily adjust the `partition` they submit to on a slurm cluster. On my cluster, you can't leave partition blank.

I can just use my own templates, I know, but thought you might find this useful. If no `partition` variable is provided in the `resources` list, it doesn't change anything.