### PR TITLE
max.concurrent.jobs for array jobs

### DIFF
--- a/R/submitJobs.R
+++ b/R/submitJobs.R
@@ -189,7 +189,7 @@ submitJobs = function(ids = NULL, resources = list(), sleep = NULL, reg = getDef
   }
 
   if (!is.na(max.concurrent.jobs)) {
-    if (uniqueN(on.sys, by = "batch.id") + !chunks.as.arrayjobs * length(chunks) + chunks.as.arrayjobs * nrow(ids) > max.concurrent.jobs) {
+    if (uniqueN(on.sys, by = "batch.id") + (!chunks.as.arrayjobs) * length(chunks) + chunks.as.arrayjobs * nrow(ids) > max.concurrent.jobs) {
       "!DEBUG [submitJobs]: Limiting the number of concurrent jobs to `max.concurrent.jobs`"
     } else {
       max.concurrent.jobs = NA_integer_

--- a/R/submitJobs.R
+++ b/R/submitJobs.R
@@ -182,7 +182,7 @@ submitJobs = function(ids = NULL, resources = list(), sleep = NULL, reg = getDef
   max.concurrent.jobs = assertCount(resources$max.concurrent.jobs, null.ok = TRUE) %??%
     assertCount(reg$max.concurrent.jobs, null.ok = TRUE) %??% NA_integer_
   if (!is.na(max.concurrent.jobs)) {
-    if (uniqueN(on.sys, by = "batch.id") + length(chunks) > max.concurrent.jobs) {
+    if (uniqueN(on.sys, by = "batch.id") + nrow(ids) > max.concurrent.jobs) {
       "!DEBUG [submitJobs]: Limiting the number of concurrent jobs to `max.concurrent.jobs`"
     } else {
       max.concurrent.jobs = NA_integer_


### PR DESCRIPTION
If `chunks.as.arrayjobs = TRUE` and `max.concurrent.jobs` is used, it should be based on jobs not chunks. 

Do we need a switch for `chunks.as.arrayjobs = FALSE`?