### PR TITLE
force evaluation of environment variables on remote

### DIFF
--- a/R/clusterFunctionsLSF.R
+++ b/R/clusterFunctionsLSF.R
@@ -59,11 +59,11 @@ makeClusterFunctionsLSF = function(template = "lsf", scheduler.latency = 1, fs.l
   }
 
   listJobsQueued = function(reg) {
-    listJobs(reg, c("-u $USER", "-w", "-p"))
+    listJobs(reg, c(shQuote("-u $USER"), "-w", "-p"))
   }
 
   listJobsRunning = function(reg) {
-    listJobs(reg, c("-u $USER", "-w", "-r"))
+    listJobs(reg, c(shQuote("-u $USER"), "-w", "-r"))
   }
 
   killJob = function(reg, batch.id) {

--- a/R/clusterFunctionsOpenLava.R
+++ b/R/clusterFunctionsOpenLava.R
@@ -59,11 +59,11 @@ makeClusterFunctionsOpenLava = function(template = "openlava", scheduler.latency
   }
 
   listJobsQueued = function(reg) {
-    listJobs(reg, c("-u $USER", "-w", "-p"))
+    listJobs(reg, c(shQuote("-u $USER"), "-w", "-p"))
   }
 
   listJobsRunning = function(reg) {
-    listJobs(reg, c("-u $USER", "-w", "-r"))
+    listJobs(reg, c(shQuote("-u $USER"), "-w", "-r"))
   }
 
   killJob = function(reg, batch.id) {

--- a/R/clusterFunctionsSGE.R
+++ b/R/clusterFunctionsSGE.R
@@ -53,11 +53,11 @@ makeClusterFunctionsSGE = function(template = "sge", scheduler.latency = 1, fs.l
   }
 
   listJobsQueued = function(reg) {
-    listJobs(reg, c("-u $USER", "-s p"))
+    listJobs(reg, c(shQuote("-u $USER"), "-s p"))
   }
 
   listJobsRunning = function(reg) {
-    listJobs(reg, c("-u $USER", "-s rs"))
+    listJobs(reg, c(shQuote("-u $USER"), "-s rs"))
   }
 
   killJob = function(reg, batch.id) {

--- a/R/clusterFunctionsSlurm.R
+++ b/R/clusterFunctionsSlurm.R
@@ -92,12 +92,12 @@ makeClusterFunctionsSlurm = function(template = "slurm", clusters = NULL, array.
   }
 
   listJobsQueued = function(reg) {
-    args = c("-h", "-o %i", "-u $USER", "-t PD", sprintf("--clusters=%s", clusters))
+    args = c("-h", "-o %i", shQuote("-u $USER"), "-t PD", sprintf("--clusters=%s", clusters))
     listJobs(reg, args)
   }
 
   listJobsRunning = function(reg) {
-    args = c("-h", "-o %i", "-u $USER", "-t R,S,CG", sprintf("--clusters=%s", clusters))
+    args = c("-h", "-o %i", shQuote("-u $USER"), "-t R,S,CG", sprintf("--clusters=%s", clusters))
     listJobs(reg, args)
   }
 

--- a/R/clusterFunctionsTORQUE.R
+++ b/R/clusterFunctionsTORQUE.R
@@ -62,12 +62,12 @@ makeClusterFunctionsTORQUE = function(template = "torque", scheduler.latency = 1
   }
 
   listJobsQueued = function(reg) {
-    args = c("-u $USER", "-s QW")
+    args = c(shQuote("-u $USER"), "-s QW")
     listJobs(reg, args)
   }
 
   listJobsRunning = function(reg) {
-    args = c("-u $USER", "-s EHRT")
+    args = c(shQuote("-u $USER"), "-s EHRT")
     listJobs(reg, args)
   }
 


### PR DESCRIPTION
Hi Michel,

I always got this error when calling the batchtools::submitJobs function:

stop(simpleError(sprintf(...), call = sys.call(sys.parent()))),
  
until I figured out that the problem occurred in the makeClusterFunctionsSlurm function. 
That was due to the fact that the environment variables is not evaluated on the remote, but from local. For my case, the problem occurs because my local username differs from the remote one. 

I identified the corresponding lines code in 
  - clusterFunctionsLSF.R
  - clusterFunctionsOpenLava.R
  - clusterFunctionsSGE.R
  - clusterFunctionsSlurm.R
  - clusterFunctionsTORQUE.R
and fixed the error with shQuote(...). 

I hope this could be helpful for the others users.

Best regards
Cesaire