### PR TITLE
qstat list fix

### DIFF
--- a/R/clusterFunctionsSGE.R
+++ b/R/clusterFunctionsSGE.R
@@ -57,11 +57,11 @@ makeClusterFunctionsSGE = function(template = "sge", nodename = "localhost", sch
   }
 
   listJobsQueued = function(reg) {
-    listJobs(reg, c(quote("-u $USER"), "-s p"))
+    listJobs(reg, c("-u $USER", "-s p"))
   }
 
   listJobsRunning = function(reg) {
-    listJobs(reg, c(quote("-u $USER"), "-s rs"))
+    listJobs(reg, c("-u $USER", "-s rs"))
   }
 
   killJob = function(reg, batch.id) {


### PR DESCRIPTION
At least in our SGE cluster, the qstat command does not recognize the quotes around -u $USER. After removing the quotes, we are now able to submit jobs from a different host that has no access to the SGE programs (qsub/qstat).