### PR TITLE
do not divide by 60

### DIFF
--- a/inst/templates/slurm-simple.tmpl
+++ b/inst/templates/slurm-simple.tmpl
@@ -26,7 +26,7 @@ log.file = fs::path_expand(log.file)
 #SBATCH --job-name=<%= job.name %>
 #SBATCH --output=<%= log.file %>
 #SBATCH --error=<%= log.file %>
-#SBATCH --time=<%= ceiling(resources$walltime / 60) %>
+#SBATCH --time=<%= ceiling(resources$walltime) %>
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=<%= resources$ncpus %>
 #SBATCH --mem-per-cpu=<%= resources$memory %>


### PR DESCRIPTION
comments/docs say that walltime resource is in minutes. it should therefore be passed directly to --time parameter (without dividing by 60) because time expects minutes. see https://slurm.schedmd.com/sbatch.html

```
       -t, --time=<time>
              Set a limit on the total run time of the job allocation.  If the requested time  limit
              exceeds  the partition’s time limit, the job will be left in a PENDING state (possibly
              indefinitely).  The default time limit is the partition’s default  time  limit.   When
              the  time  limit  is  reached,  each task in each job step is sent SIGTERM followed by
              SIGKILL.  The interval between signals is specified by the Slurm configuration parame-
              ter  KillWait.   The  OverTimeLimit  configuration parameter may permit the job to run
              longer than scheduled.  Time resolution is one minute and second values are rounded up
              to the next minute.

              A  time limit of zero requests that no time limit be imposed.  Acceptable time formats
              include   "minutes",   "minutes:seconds",    "hours:minutes:seconds",    "days-hours",
              "days-hours:minutes" and "days-hours:minutes:seconds".
```

The important part is `Acceptable time formats include   "minutes",` which means that raw numbers given to the --time parameter are interpreted as minutes

Also you probably want to fix the relevant part of the other slurm templates