### PR TITLE
Fix job name option (-j -> -J) and add spaces for readability.

### DIFF
--- a/inst/templates/lsf-simple.tmpl
+++ b/inst/templates/lsf-simple.tmpl
@@ -1,11 +1,11 @@
 ## Default resources can be set in your .batchtools.conf.R by defining the variable
 ## 'default.resources' as a named list.
 
-#BSUB-j <%= job.name %>                             # Name of the job
-#BSUB-o <%= log.file %>                             # Output is sent to logfile, stdout + stderr by default
-#BSUB-q <%= resources$queue %>                      # Job queue
-#BSUB-W <%= round(resources$walltime / 60, 1) %>    # Walltime (LSF requires minutes, batchtools uses seconds)
-#BSUB-M <%= resources$memory %>                     # Memory requirements in KBytes; depends on setting LSF_UNIT_FOR_LIMITS in lsf.conf
+#BSUB -J <%= job.name %>                             # Name of the job
+#BSUB -o <%= log.file %>                             # Output is sent to logfile, stdout + stderr by default
+#BSUB -q <%= resources$queue %>                      # Job queue
+#BSUB -W <%= round(resources$walltime / 60, 1) %>    # Walltime (LSF requires minutes, batchtools uses seconds)
+#BSUB -M <%= resources$memory %>                     # Memory requirements, e.g. "5000KB", "500MB", "5GB" etc. 
 
 ## Export value of DEBUGME environemnt var to slave
 export DEBUGME=<%= Sys.getenv("DEBUGME") %>


### PR DESCRIPTION
the `-j` option needs to be uppercase `-J`. The spaces are cosmetic but follow upstream documentation convention.