### PR TITLE
allow for more than one partition

### DIFF
--- a/inst/templates/slurm-simple.tmpl
+++ b/inst/templates/slurm-simple.tmpl
@@ -30,7 +30,7 @@ log.file = fs::path_expand(log.file)
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=<%= resources$ncpus %>
 #SBATCH --mem-per-cpu=<%= resources$memory %>
-<%= if (!is.null(resources$partition)) sprintf(paste0("#SBATCH --partition='", resources$partition, "'")) %>
+<%= if (!is.null(resources$partition)) sprintf(paste0("#SBATCH --partition='", paste(resources$partition, collapse = ","), "'")) %>
 <%= if (array.jobs) sprintf("#SBATCH --array=1-%i", nrow(jobs)) else "" %>
 
 ## Initialize work environment like


### PR DESCRIPTION
See documentation https://slurm.schedmd.com/sbatch.html:
> If the job can use more than one partition, specify their names in a comma separate list and the one offering earliest initiation will be used with no regard given to the partition name ordering (although higher priority partitions will be considered first).

The current behaviour works, however, it is surprising (only the first partition gets used):

``` r
resources <- list(partition = c("short", "long"))
# old, string gets repeated, slurm uses only first
sprintf(paste0("#SBATCH --partition='", resources$partition, "'"))
#> [1] "#SBATCH --partition='short'" "#SBATCH --partition='long'"
# new, comma seperated list
sprintf(paste0("#SBATCH --partition='", paste(resources$partition, collapse = ","), "'"))
#> [1] "#SBATCH --partition='short,long'"
```

<sup>Created on 2021-04-09 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>